### PR TITLE
Remove exclude undefined types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-create-reducer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-create-reducer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A utility to create redux reducers from a set of handlers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import { Action, AnyAction, Reducer } from 'redux';
 
 const INVALID_HANDLER_KEYS = ['undefined', 'null'];
 
-export type Handlers<S, A extends Action = AnyAction> = {
+type NotUndefined = {} | null;
+
+export type Handlers<S extends NotUndefined, A extends Action = AnyAction> = {
   [P in A['type']]: (state: S, action: A) => S
 };
 
@@ -14,10 +16,10 @@ function validateKeys(handlers: Handlers<any, any>) {
   });
 }
 
-export function createReducer<S, A extends Action = AnyAction>(
-  handlers: Handlers<S, A>,
-  initialState: S
-): Reducer<S, A> {
+export function createReducer<
+  S extends NotUndefined,
+  A extends Action = AnyAction
+>(handlers: Handlers<S, A>, initialState: S): Reducer<S, A> {
   if (
     !handlers ||
     typeof (handlers as Handlers<S, A> | undefined) !== 'object' ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Action, AnyAction, Reducer } from 'redux';
 const INVALID_HANDLER_KEYS = ['undefined', 'null'];
 
 export type Handlers<S, A extends Action = AnyAction> = {
-  [P in A['type']]: (state: S, action: A) => Exclude<S, undefined>
+  [P in A['type']]: (state: S, action: A) => S
 };
 
 function validateKeys(handlers: Handlers<any, any>) {
@@ -16,7 +16,7 @@ function validateKeys(handlers: Handlers<any, any>) {
 
 export function createReducer<S, A extends Action = AnyAction>(
   handlers: Handlers<S, A>,
-  initialState: Exclude<S, undefined>
+  initialState: S
 ): Reducer<S, A> {
   if (
     !handlers ||

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -37,10 +37,7 @@ describe('createReducer', () => {
 
   it('should error if the initial state is undefined', () => {
     expect(() =>
-      createReducer<null | undefined>(
-        { foo: () => null },
-        (undefined as unknown) as null
-      )
+      createReducer({ foo: () => null }, (undefined as unknown) as null)
     ).toThrow(MATCHES_INVALID_INITIAL_STATE);
   });
 


### PR DESCRIPTION
This change disallows passing `undefined`, `void` and `unknown` generics.

This will be a patch version as it is backward compatible.

There was previously a clash when calling the function with a type that was already generic as:

```ts
const abstraction = <S>(initialState: S) => {
  return createReducer<S, {payload: S}>({
    key: (_state, action) => {
      return action.payload; // S is not assignable to Exclude<S, undefined>
    }
  }, initialState);
};
```