### PR TITLE
Type overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,46 +22,18 @@ npm i @dabapps/redux-create-reducer -S
 import { createReducer } from '@dabapps/redux-create-reducer';
 import { ADD, SUBTRACT, RESET } from './action-types';
 
-export const count = createReducer(
-  {
-    [ADD]: (state, action) => state + action.payload,
-    [SUBTRACT]: (state, action) => state - action.payload,
-    [RESET]: () => 0,
-  },
-  0 // Initial state (required)
-);
-```
-
-## TypeScript
-
-You can supply a generic type for the reducer state, and the actions it should handle:
-
-```ts
 interface NumberAction {
   type: string;
   payload: number;
 }
 
-export const count = createReducer<number, NumberAction>(
-  // ...
-);
-```
-
-You can use the action generic parameter to narrow the available handlers by setting specific `type` keys:
-
-```ts
-interface NumberAction {
-  type: 'ADD' | 'SUBTRACT' | 'RESET';
-  payload: number;
-}
-
-export const count = createReducer<number, NumberAction>(
+export const count = createReducer(
   {
-    // ...
-    // The next line will have a type error because MULTIPLY was not defined in our type interface
-    [MULTIPLY]: (state, action) => state * action.payload,
+    [ADD]: (state: number, action: NumberAction) => state + action.payload,
+    [SUBTRACT]: (state: number, action: NumberAction) => state - action.payload,
+    [RESET]: () => 0,
   },
-  // ...
+  0 // Initial state (required)
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm i @dabapps/redux-create-reducer -S
 
 ## Usage
 
-```js
+```ts
 import { createReducer } from '@dabapps/redux-create-reducer';
 import { ADD, SUBTRACT, RESET } from './action-types';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-create-reducer",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-create-reducer",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A utility to create redux reducers from a set of handlers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ function validateKeys(handlers: Record<string, unknown>) {
 export function createReducer<
   S extends NotUndefined,
   A extends Action<T>,
-  T extends string
+  T extends string | symbol
 >(
   handlers: {
     [P in T]: (state: S, action: ActionOfType<A, P>) => S;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
-import { Action, AnyAction, Reducer } from 'redux';
+import { Action, Reducer } from 'redux';
 
 const INVALID_HANDLER_KEYS = ['undefined', 'null'];
 
 type NotUndefined = {} | null;
 
-export type Handlers<S extends NotUndefined, A extends Action = AnyAction> = {
-  [P in A['type']]: (state: S, action: A) => S;
-};
+type ActionOfType<A extends Action, T> = Exclude<A, Exclude<A, { type: T }>>;
 
-function validateKeys(handlers: Handlers<any, any>) {
+function validateKeys(handlers: Record<string, unknown>) {
   INVALID_HANDLER_KEYS.forEach(key => {
     if (Object.prototype.hasOwnProperty.call(handlers, key)) {
       throw new Error(`Invalid createReducer handler key: ${key}`);
@@ -18,11 +16,18 @@ function validateKeys(handlers: Handlers<any, any>) {
 
 export function createReducer<
   S extends NotUndefined,
-  A extends Action = AnyAction
->(handlers: Handlers<S, A>, initialState: S): Reducer<S, A> {
+  A extends Action<T>,
+  T extends string
+>(
+  handlers: {
+    [P in T]: (state: S, action: ActionOfType<A, P>) => S;
+  },
+  initialState: S
+): Reducer<S, ActionOfType<A, T>> {
   if (
     !handlers ||
-    typeof (handlers as Handlers<S, A> | undefined) !== 'object' ||
+    // tslint:disable-next-line:strict-type-predicates
+    typeof handlers !== 'object' ||
     Array.isArray(handlers)
   ) {
     throw new Error(
@@ -36,11 +41,12 @@ export function createReducer<
 
   validateKeys(handlers);
 
-  return (state: S = initialState, action: A): S => {
+  return (state: S = initialState, action: ActionOfType<A, T>): S => {
     const { type } = action;
 
     if (Object.prototype.hasOwnProperty.call(handlers, type)) {
-      return handlers[type as keyof Handlers<S, A>](state, action);
+      const handler = handlers[type];
+      return handler(state, action);
     }
 
     return state;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Action, Reducer } from 'redux';
+import { Action, AnyAction, Reducer } from 'redux';
 
 const INVALID_HANDLER_KEYS = ['undefined', 'null'];
 
@@ -23,7 +23,7 @@ export function createReducer<
     [P in T]: (state: S, action: ActionOfType<A, P>) => S;
   },
   initialState: S
-): Reducer<S, ActionOfType<A, T>> {
+) {
   if (
     !handlers ||
     // tslint:disable-next-line:strict-type-predicates
@@ -41,7 +41,7 @@ export function createReducer<
 
   validateKeys(handlers);
 
-  return (state: S = initialState, action: ActionOfType<A, T>): S => {
+  return ((state: S = initialState, action: ActionOfType<A, T>): S => {
     const { type } = action;
 
     if (Object.prototype.hasOwnProperty.call(handlers, type)) {
@@ -50,5 +50,5 @@ export function createReducer<
     }
 
     return state;
-  };
+  }) as Reducer<S, AnyAction>;
 }

--- a/tests/index.tsx
+++ b/tests/index.tsx
@@ -1,4 +1,4 @@
-import { createReducer, Handlers } from '../src';
+import { createReducer } from '../src';
 
 describe('createReducer', () => {
   const MATCHES_INVALID_KEY = /\binvalid\b.+\bkey\b/i;
@@ -12,9 +12,9 @@ describe('createReducer', () => {
   });
 
   it('returns the initialState when an unknown action is emitted', () => {
-    const reducer = createReducer<number>(
+    const reducer = createReducer(
       {
-        foo: state => state + 1,
+        foo: (state: number) => state + 1,
       },
       0
     );
@@ -42,15 +42,15 @@ describe('createReducer', () => {
   });
 
   it('should error if the handlers are not a string keyed object', () => {
-    expect(() =>
-      createReducer((null as unknown) as Handlers<any, any>, null)
-    ).toThrow(MATCHES_INVALID_HANDLERS);
-    expect(() =>
-      createReducer(([] as unknown) as Handlers<any, any>, null)
-    ).toThrow(MATCHES_INVALID_HANDLERS);
-    expect(() =>
-      createReducer((undefined as unknown) as Handlers<any, any>, null)
-    ).toThrow(MATCHES_INVALID_HANDLERS);
+    expect(() => createReducer(null as any, null)).toThrow(
+      MATCHES_INVALID_HANDLERS
+    );
+    expect(() => createReducer([] as any, null)).toThrow(
+      MATCHES_INVALID_HANDLERS
+    );
+    expect(() => createReducer(undefined as any, null)).toThrow(
+      MATCHES_INVALID_HANDLERS
+    );
   });
 
   it('should handler multiple actions (including symbols)', () => {
@@ -70,10 +70,10 @@ describe('createReducer', () => {
       payload: count,
     });
 
-    const reducer = createReducer<number, NumberAction>(
+    const reducer = createReducer(
       {
-        [ADD]: (state, action) => state + action.payload,
-        [SUB]: (state, action) => state - action.payload,
+        [ADD]: (state: number, action: NumberAction) => state + action.payload,
+        [SUB]: (state: number, action: NumberAction) => state - action.payload,
       },
       5
     );


### PR DESCRIPTION
Adjustments to disallow `AnyAction` by accident (no action type supplied), better action inference, and allow `AnyAction` to be passed into the resultant reducer.

Advise against explicitly passing generic paramaters.